### PR TITLE
Replace mecanum controller with diff drive

### DIFF
--- a/src/rm_nav_bringup/urdf/sentry_robot_sim.xacro
+++ b/src/rm_nav_bringup/urdf/sentry_robot_sim.xacro
@@ -203,34 +203,20 @@
   </gazebo>
 
   <!-- Drive controller plugin-->
-  <!-- https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration:-Planar-Move -->
+  <!-- Gazebo ROS diff drive controller -->
   <gazebo>
-    <plugin name="mecanum_controller" filename="libgazebo_ros_planar_move.so">
+    <plugin name="diff_drive_controller" filename="libgazebo_ros_diff_drive.so">
       <ros>
-        <!-- Add a namespace -->
         <namespace>/</namespace>
-        <!-- Remap the default topic -->
-        <remapping>cmd_vel:=cmd_vel_chassis</remapping>
-        <remapping>odom:=odom</remapping>
       </ros>
-
-      <!-- Set control loop update rate -->
-      <update_rate>100</update_rate>
-      <!-- Set odom publish rate -->
-      <publish_rate>10</publish_rate>
-
-      <!-- Set if odom required -->
-      <publish_odom>false</publish_odom>
-      <publish_odom_tf>false</publish_odom_tf>
-
-      <!-- Frame IDs -->
-      <odometry_frame>odom</odometry_frame>
-      <robot_base_frame>base_link</robot_base_frame>
-
-      <!-- Set odom covariance -->
-      <covariance_x>0.0001</covariance_x>
-      <covariance_y>0.0001</covariance_y>
-      <covariance_yaw>0.01</covariance_yaw>
+      <left_joint>base_to_wheel1</left_joint>
+      <left_joint>base_to_wheel2</left_joint>
+      <right_joint>base_to_wheel3</right_joint>
+      <right_joint>base_to_wheel4</right_joint>
+      <wheel_separation>0.26</wheel_separation>
+      <wheel_radius>0.06</wheel_radius>
+      <command_topic>/cmd_vel</command_topic>
+      <odometry_topic>/odom</odometry_topic>
     </plugin>
   </gazebo>
 

--- a/src/rm_simulation/pb_rm_simulation/urdf/simulation_waking_robot.xacro
+++ b/src/rm_simulation/pb_rm_simulation/urdf/simulation_waking_robot.xacro
@@ -203,34 +203,20 @@
   </gazebo>
 
   <!-- Drive controller plugin-->
-  <!-- https://github.com/ros-simulation/gazebo_ros_pkgs/wiki/ROS-2-Migration:-Planar-Move -->
+  <!-- Gazebo ROS diff drive controller -->
   <gazebo>
-    <plugin name="mecanum_controller" filename="libgazebo_ros_planar_move.so">
+    <plugin name="diff_drive_controller" filename="libgazebo_ros_diff_drive.so">
       <ros>
-        <!-- Add a namespace -->
         <namespace>/</namespace>
-        <!-- Remap the default topic -->
-        <remapping>cmd_vel:=cmd_vel_chassis</remapping>
-        <remapping>odom:=odom</remapping>
       </ros>
-
-      <!-- Set control loop update rate -->
-      <update_rate>100</update_rate>
-      <!-- Set odom publish rate -->
-      <publish_rate>10</publish_rate>
-
-      <!-- Set if odom required -->
-      <publish_odom>false</publish_odom>
-      <publish_odom_tf>false</publish_odom_tf>
-
-      <!-- Frame IDs -->
-      <odometry_frame>odom</odometry_frame>
-      <robot_base_frame>base_link</robot_base_frame>
-
-      <!-- Set odom covariance -->
-      <covariance_x>0.0001</covariance_x>
-      <covariance_y>0.0001</covariance_y>
-      <covariance_yaw>0.01</covariance_yaw>
+      <left_joint>base_to_wheel1</left_joint>
+      <left_joint>base_to_wheel2</left_joint>
+      <right_joint>base_to_wheel3</right_joint>
+      <right_joint>base_to_wheel4</right_joint>
+      <wheel_separation>0.26</wheel_separation>
+      <wheel_radius>0.06</wheel_radius>
+      <command_topic>/cmd_vel</command_topic>
+      <odometry_topic>/odom</odometry_topic>
     </plugin>
   </gazebo>
 


### PR DESCRIPTION
## Summary
- switch simulation xacros to use `gazebo_ros_diff_drive` with four wheel joints
- remove remap to `cmd_vel_chassis`

## Testing
- `colcon test --packages-select rm_simulation rm_nav_bringup` *(fails: command not found: colcon)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d428aaa34832f8f08edd1ca0793c9