### PR TITLE
Use base_footprint frame for navigation and visualization

### DIFF
--- a/src/rm_nav_bringup/config/reality/nav2_params_real.yaml
+++ b/src/rm_nav_bringup/config/reality/nav2_params_real.yaml
@@ -6,7 +6,7 @@ amcl:
     alpha3: 0.2
     alpha4: 0.2
     alpha5: 0.2
-    base_frame_id: "base_link"
+    base_frame_id: "base_footprint"
     beam_skip_distance: 0.5
     beam_skip_error_threshold: 0.9
     beam_skip_threshold: 0.3
@@ -51,7 +51,7 @@ bt_navigator:
   ros__parameters:
     use_sim_time: False
     global_frame: map
-    robot_base_frame: base_link
+    robot_base_frame: base_footprint
     odom_topic: /Odometry
     bt_loop_duration: 10
     default_server_timeout: 20

--- a/src/rm_nav_bringup/config/simulation/nav2_params_sim.yaml
+++ b/src/rm_nav_bringup/config/simulation/nav2_params_sim.yaml
@@ -6,7 +6,7 @@ amcl:
     alpha3: 0.2
     alpha4: 0.2
     alpha5: 0.2
-    base_frame_id: "base_link"
+    base_frame_id: "base_footprint"
     beam_skip_distance: 0.5
     beam_skip_error_threshold: 0.9
     beam_skip_threshold: 0.3
@@ -51,7 +51,7 @@ bt_navigator:
   ros__parameters:
     use_sim_time: False
     global_frame: map
-    robot_base_frame: base_link
+    robot_base_frame: base_footprint
     odom_topic: /Odometry
     bt_loop_duration: 10
     default_server_timeout: 20
@@ -165,7 +165,7 @@ local_costmap:
       update_frequency: 20.0
       publish_frequency: 10.0
       global_frame: map
-      robot_base_frame: base_link
+      robot_base_frame: base_footprint
       use_sim_time: False
       rolling_window: true
       width: 5
@@ -199,7 +199,7 @@ global_costmap:
       update_frequency: 5.0
       publish_frequency: 2.0
       global_frame: map
-      robot_base_frame: base_link
+      robot_base_frame: base_footprint
       use_sim_time: False
       robot_radius: 0.2
       resolution: 0.04
@@ -289,7 +289,7 @@ recoveries_server:
     backup:
       plugin: "nav2_recoveries/BackUp"
     global_frame: odom
-    robot_base_frame: base_link
+    robot_base_frame: base_footprint
     transform_timeout: 0.1
     use_sim_time: False
     simulate_ahead_time: 1.0

--- a/src/rm_nav_bringup/rviz/pointlio.rviz
+++ b/src/rm_nav_bringup/rviz/pointlio.rviz
@@ -34,7 +34,7 @@ Visualization Manager:
       Frame Timeout: 15
       Frames:
         All Enabled: true
-        base_link:
+        base_footprint:
           Value: true
         base_link_fake:
           Value: true
@@ -63,21 +63,22 @@ Visualization Manager:
         map:
           {}
         odom:
-          base_link:
-            base_link_fake:
-              {}
-            imu_link:
-              {}
-            livox_frame:
-              {}
-            wheel_1:
-              {}
-            wheel_2:
-              {}
-            wheel_3:
-              {}
-            wheel_4:
-              {}
+          base_footprint:
+            base_link:
+              base_link_fake:
+                {}
+              imu_link:
+                {}
+              livox_frame:
+                {}
+              wheel_1:
+                {}
+              wheel_2:
+                {}
+              wheel_3:
+                {}
+              wheel_4:
+                {}
       Update Interval: 0
       Value: true
     - Angle Tolerance: 0.10000000149011612

--- a/src/rm_nav_bringup/urdf/sentry_robot_real.xacro
+++ b/src/rm_nav_bringup/urdf/sentry_robot_real.xacro
@@ -36,6 +36,13 @@
     <xacro:default_inertial mass="8.2"/>
   </link>
 
+  <link name="base_footprint"/>
+  <joint name="base_footprint_joint" type="fixed">
+    <parent link="base_footprint"/>
+    <child link="base_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+
   <link name="wheel_1">
     <visual>
       <geometry>

--- a/src/rm_nav_bringup/urdf/sentry_robot_sim.xacro
+++ b/src/rm_nav_bringup/urdf/sentry_robot_sim.xacro
@@ -38,9 +38,16 @@
     <xacro:default_inertial mass="8.2"/>
   </link>
 
+  <link name="base_footprint"/>
+  <joint name="base_footprint_joint" type="fixed">
+    <parent link="base_footprint"/>
+    <child link="base_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+
   <joint name="dummy_joint" type="fixed">
      <parent link="dummy"/>
-     <child link="base_link"/>
+     <child link="base_footprint"/>
   </joint>
 
   <link name="wheel_1">

--- a/src/rm_navigation/rm_navigation/rviz/nav2.rviz
+++ b/src/rm_navigation/rm_navigation/rviz/nav2.rviz
@@ -61,6 +61,11 @@ Visualization Manager:
         Expand Link Details: false
         Expand Tree: false
         Link Tree Style: Links in Alphabetic Order
+        base_footprint:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         base_link:
           Alpha: 1
           Show Axes: false
@@ -112,7 +117,7 @@ Visualization Manager:
       Frame Timeout: 15
       Frames:
         All Enabled: false
-        base_link:
+        base_footprint:
           Value: true
         base_link_fake:
           Value: true
@@ -143,21 +148,22 @@ Visualization Manager:
         map:
           odom:
             lidar_odom:
-              base_link:
-                base_link_fake:
-                  {}
-                imu_link:
-                  {}
-                livox_frame:
-                  {}
-                wheel_1:
-                  {}
-                wheel_2:
-                  {}
-                wheel_3:
-                  {}
-                wheel_4:
-                  {}
+              base_footprint:
+                base_link:
+                  base_link_fake:
+                    {}
+                  imu_link:
+                    {}
+                  livox_frame:
+                    {}
+                  wheel_1:
+                    {}
+                  wheel_2:
+                    {}
+                  wheel_3:
+                    {}
+                  wheel_4:
+                    {}
       Update Interval: 0
       Value: true
     - Alpha: 1

--- a/src/rm_simulation/pb_rm_simulation/rviz/rviz2.rviz
+++ b/src/rm_simulation/pb_rm_simulation/rviz/rviz2.rviz
@@ -122,8 +122,6 @@ Visualization Manager:
         All Enabled: true
         base_footprint:
           Value: true
-        base_link:
-          Value: true
         camera_link:
           Value: true
         imu_link:
@@ -240,7 +238,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: base_link
+    Fixed Frame: base_footprint
     Frame Rate: 30
   Name: root
   Tools:

--- a/src/rm_simulation/pb_rm_simulation/urdf/simulation_waking_robot.xacro
+++ b/src/rm_simulation/pb_rm_simulation/urdf/simulation_waking_robot.xacro
@@ -38,9 +38,16 @@
     <xacro:default_inertial mass="8.2"/>
   </link>
 
+  <link name="base_footprint"/>
+  <joint name="base_footprint_joint" type="fixed">
+    <parent link="base_footprint"/>
+    <child link="base_link"/>
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </joint>
+
   <joint name="dummy_joint" type="fixed">
      <parent link="dummy"/>
-     <child link="base_link"/>
+     <child link="base_footprint"/>
   </joint>
 
   <link name="wheel_1">


### PR DESCRIPTION
## Summary
- insert `base_footprint` link and fixed joint into robot URDFs
- switch Nav2 configs to use `base_footprint` as the base frame
- update RViz configs to display `base_footprint`

## Testing
- `colcon test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689ecdde92d0832fb5547925b9a5d6ab